### PR TITLE
removing extra thulium link

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,6 @@
         <li><a href="https://github.com/pateketrueke/route-mappings">Route Mappings</a></li>
         <li><a href="https://github.com/freshout-dev/thulium/">Thulium</a></li>
         <li><a href="https://github.com/sgarza/thulium-express">thulium-express</a></li>
-        <li><a href="https://github.com/sgarza/thulium-express">thulium-express</a></li>
         <li><a href="https://webpack.github.io/">Webpack</a></li>
       </ul>
 


### PR DESCRIPTION
This PR removes a repeated link to `thulium-express` in the documentation.
