### PR TITLE
adding links to releases diff in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 2016-05-31, Version 0.0.3
+## [Unreleased]
+
+## 2016-05-31, Version [0.0.3]
 - Removed RouteMapper
 - Added RouteMappings
 - Add locals.routeMappings helper
 - Add server listening info
 
-## 2016-05-05, Version 0.0.2
+## 2016-05-05, Version [0.0.2]
 - Add knex to boot.js
 - Bind knex to Krypton.Model in boot.js
 - Don't reverse controller's beforeActions
@@ -14,3 +16,7 @@
 
 ## 2016-01-06, Version 0.0.1
 - First Release
+
+[Unreleased]: https://github.com/wobe-pte-ltd/wobe/compare/0.0.3...HEAD
+[0.0.3]: https://github.com/Empathia/neonode/compare/0.0.2...0.0.3
+[0.0.2]: https://github.com/Empathia/neonode/compare/0.0.1...0.0.2


### PR DESCRIPTION
This PR adds links to versions diffs in the CHANGELOG.md, following suggestions from http://keepachangelog.com/
